### PR TITLE
Enable headless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# FeatherFrame
+
+This project provides a camera management application written in Go. It can run
+in a TUI for setup or in headless mode for deployments.
+
+## Running Headless
+
+Headless mode starts the web server and camera stream without the TUI. The
+configuration is read from `~/.config/featherframe/config.json`.
+
+```
+$ go run cmd/featherframe/main.go
+```
+
+To enable headless mode set `"headless": true` in the config file.
+
+## Container Usage
+
+A Dockerfile is not provided, but the application should work with the official
+`gocv` images for ARM64. Install OpenCV and gocv in the container, copy the
+source, then build:
+
+```
+FROM gocv/gocv:latest
+WORKDIR /app
+COPY . .
+RUN go build -o featherframe cmd/featherframe/main.go
+CMD ["./featherframe"]
+```
+
+Bind mount `/dev/video0` and expose the configured port.

--- a/cmd/featherframe/main.go
+++ b/cmd/featherframe/main.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/AlverezYari/featherframe/internal/config"
+	"github.com/AlverezYari/featherframe/internal/headless"
 	"github.com/AlverezYari/featherframe/internal/tui"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -32,10 +33,11 @@ func main() {
 	// check and launch app in the correct mode TUI/headless
 
 	if config.Headless {
-		// start app in headless mode
-		//
 		fmt.Println("Starting app in headless mode!")
-
+		if err := headless.NewHeadless(configPath, config); err != nil {
+			fmt.Printf("Headless mode error: %v", err)
+			os.Exit(1)
+		}
 	} else {
 		// start app in tui mode
 


### PR DESCRIPTION
## Summary
- hook up headless execution in `main.go`
- add short README with headless and container notes

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*