### PR TITLE
Add Prometheus-style metrics endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,19 @@ CMD ["./featherframe"]
 ```
 
 Bind mount `/dev/video0` and expose the configured port.
+
+## Metrics
+
+A Prometheus-compatible endpoint is available at `/metrics`. Two counters are
+provided:
+
+- `birds_seen` – counts bird detections
+- `birds_captured` – counts saved captures
+
+The values can be incremented via the `/api/birds_sceen` and
+`/api/birds_captured` endpoints. These return `204 No Content` when called.
+
+Additional generic metrics are exposed:
+
+- `http_requests_total` – total HTTP requests served
+- `uptime_seconds` – seconds since the server started

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,70 @@
+package metrics
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+var birdsSeen uint64
+var birdsCaptured uint64
+var httpRequests uint64
+var startTime time.Time
+
+// SetStartTime records when the application began running so uptime can be
+// calculated.
+func SetStartTime(t time.Time) {
+	startTime = t
+}
+
+func IncrementBirdsSeen() {
+	atomic.AddUint64(&birdsSeen, 1)
+}
+
+func IncrementBirdsCaptured() {
+	atomic.AddUint64(&birdsCaptured, 1)
+}
+
+// IncrementRequests increases the http request counter.
+func IncrementRequests() {
+	atomic.AddUint64(&httpRequests, 1)
+}
+
+// RequestMiddleware wraps an http.Handler and increments the request counter
+// for each request before calling the next handler.
+func RequestMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		IncrementRequests()
+		next.ServeHTTP(w, r)
+	})
+}
+
+func MetricsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+	fmt.Fprintf(w, "# HELP birds_seen Number of birds detected\n")
+	fmt.Fprintf(w, "# TYPE birds_seen counter\n")
+	fmt.Fprintf(w, "birds_seen %d\n", atomic.LoadUint64(&birdsSeen))
+	fmt.Fprintf(w, "# HELP birds_captured Number of birds captured\n")
+	fmt.Fprintf(w, "# TYPE birds_captured counter\n")
+	fmt.Fprintf(w, "birds_captured %d\n", atomic.LoadUint64(&birdsCaptured))
+	fmt.Fprintf(w, "# HELP http_requests_total Total HTTP requests\n")
+	fmt.Fprintf(w, "# TYPE http_requests_total counter\n")
+	fmt.Fprintf(w, "http_requests_total %d\n", atomic.LoadUint64(&httpRequests))
+	if !startTime.IsZero() {
+		uptime := time.Since(startTime).Seconds()
+		fmt.Fprintf(w, "# HELP uptime_seconds Application uptime in seconds\n")
+		fmt.Fprintf(w, "# TYPE uptime_seconds gauge\n")
+		fmt.Fprintf(w, "uptime_seconds %.0f\n", uptime)
+	}
+}
+
+func BirdsSeenHandler(w http.ResponseWriter, r *http.Request) {
+	IncrementBirdsSeen()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func BirdsCapturedHandler(w http.ResponseWriter, r *http.Request) {
+	IncrementBirdsCaptured()
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/AlverezYari/featherframe/internal/config"
+	"github.com/AlverezYari/featherframe/internal/metrics"
 	"github.com/AlverezYari/featherframe/pkg/camera"
 	"github.com/gorilla/websocket"
 )
@@ -64,6 +65,7 @@ func (s *Server) Start() error {
 	}
 
 	mux := http.NewServeMux()
+	metrics.SetStartTime(time.Now())
 	// Separate handlers for streaming sites
 	mux.HandleFunc("/ws/setupPreview", s.handleWebSocketPreview)
 	mux.HandleFunc("/ws/liveMonitor", s.handleWebSocketLive)
@@ -94,11 +96,15 @@ func (s *Server) Start() error {
 	})
 
 	mux.HandleFunc("/api/screenshot", s.handleScreenshot)
+	// Prometheus metrics endpoints
+	mux.HandleFunc("/metrics", metrics.MetricsHandler)
+	mux.HandleFunc("/api/birds_sceen", metrics.BirdsSeenHandler)
+	mux.HandleFunc("/api/birds_captured", metrics.BirdsCapturedHandler)
 
 	// Build and start the HTTP server
 	s.server = &http.Server{
 		Addr:    ":" + s.port,
-		Handler: mux,
+		Handler: metrics.RequestMiddleware(mux),
 	}
 
 	go func() {


### PR DESCRIPTION
## Summary
- implement internal metrics package
- expose `/metrics` handler and stub increment endpoints
- add uptime and HTTP request metrics

## Testing
- `go test ./...` *(fails: no route to host)*