### PR TITLE
Add detector skeleton in Go

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,12 +20,21 @@ type CameraConfig struct {
 	StreamConfig StreamConfig `json:"stream_config"`
 }
 
+type DetectionConfig struct {
+	ModelPath   string  `json:"model_path"`
+	LabelPath   string  `json:"label_path"`
+	Confidence  float32 `json:"confidence"`
+	InputWidth  int     `json:"input_width"`
+	InputHeight int     `json:"input_height"`
+}
+
 type AppConfig struct {
-	ServerPort   string       `json:"server_port"`
-	ServerIP     string       `json:"server_ip"`
-	CameraConfig CameraConfig `json:"camera"`
-	StoragePath  string       `json:"storage_path"`
-	Headless     bool         `json:"headless"`
+	ServerPort      string          `json:"server_port"`
+	ServerIP        string          `json:"server_ip"`
+	CameraConfig    CameraConfig    `json:"camera"`
+	StoragePath     string          `json:"storage_path"`
+	Headless        bool            `json:"headless"`
+	DetectionConfig DetectionConfig `json:"detection"`
 }
 
 // Default config
@@ -42,6 +51,13 @@ func defaultConfig() *AppConfig {
 		ServerPort:  "8080",
 		StoragePath: "",
 		Headless:    false,
+		DetectionConfig: DetectionConfig{
+			ModelPath:   "models/detector.onnx",
+			LabelPath:   "models/labels.txt",
+			Confidence:  0.5,
+			InputWidth:  640,
+			InputHeight: 640,
+		},
 	}
 }
 

--- a/internal/detector/detector.go
+++ b/internal/detector/detector.go
@@ -1,0 +1,86 @@
+package detector
+
+import (
+	"bufio"
+	"fmt"
+	"image"
+	"os"
+
+	"gocv.io/x/gocv"
+)
+
+// Detection represents one object prediction result.
+type Detection struct {
+	ClassID    int
+	Label      string
+	Confidence float32
+	Box        image.Rectangle
+}
+
+// Detector wraps a gocv.Net for running inference.
+type Detector struct {
+	net           gocv.Net
+	labels        []string
+	inputWidth    int
+	inputHeight   int
+	confThreshold float32
+}
+
+// New returns a Detector using the provided ONNX model and label file.
+func New(modelPath, labelPath string, inputW, inputH int, conf float32) (*Detector, error) {
+	net := gocv.ReadNet(modelPath, "")
+	if net.Empty() {
+		return nil, fmt.Errorf("failed to load model at %s", modelPath)
+	}
+
+	labels, err := loadLabels(labelPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Detector{
+		net:           net,
+		labels:        labels,
+		inputWidth:    inputW,
+		inputHeight:   inputH,
+		confThreshold: conf,
+	}, nil
+}
+
+// Close releases resources used by the detector.
+func (d *Detector) Close() {
+	if !d.net.Empty() {
+		d.net.Close()
+	}
+}
+
+// Detect runs inference on the provided Mat and returns detections.
+// TODO: adapt this to the chosen model's output format.
+func (d *Detector) Detect(img gocv.Mat) ([]Detection, error) {
+	blob := gocv.BlobFromImage(img, 1/255.0, image.Pt(d.inputWidth, d.inputHeight), gocv.NewScalar(0, 0, 0, 0), true, false)
+	defer blob.Close()
+
+	d.net.SetInput(blob, "")
+
+	preds := d.net.Forward("")
+	defer preds.Close()
+
+	// Parsing model output is model-specific. Implementation left as TODO.
+	// Returning empty slice for now.
+	return nil, nil
+}
+
+func loadLabels(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open labels: %w", err)
+	}
+	defer f.Close()
+
+	var labels []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		labels = append(labels, scanner.Text())
+	}
+	return labels, scanner.Err()
+}

--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -52,6 +52,18 @@ func NewHeadless(configPath string, cfg *config.AppConfig) error {
 		AutoStart: true,
 	}
 
+	// Initialize detector
+	det, errDet := detector.New(
+		cfg.DetectionConfig.ModelPath,
+		cfg.DetectionConfig.LabelPath,
+		cfg.DetectionConfig.InputWidth,
+		cfg.DetectionConfig.InputHeight,
+		cfg.DetectionConfig.Confidence,
+	)
+	if errDet != nil {
+		return fmt.Errorf("headless: detector init failed: %w", errDet)
+	}
+
 	// Start our webserver
 	srv := server.New(
 		cfg.ServerPort,
@@ -62,6 +74,7 @@ func NewHeadless(configPath string, cfg *config.AppConfig) error {
 		camMgr,
 		cfg.CameraConfig.DeviceID,
 		cfg,
+		det,
 	)
 	if err := srv.Start(); err != nil {
 		return fmt.Errorf("headless: failed to start the webserver: %w", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,18 +3,23 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"html/template"
+	"image/color"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/AlverezYari/featherframe/internal/config"
+	"github.com/AlverezYari/featherframe/internal/detector"
 	"github.com/AlverezYari/featherframe/internal/metrics"
 	"github.com/AlverezYari/featherframe/pkg/camera"
 	"github.com/gorilla/websocket"
+	"gocv.io/x/gocv"
 )
 
 type LogEntry struct {
@@ -35,6 +40,7 @@ type Server struct {
 	cameraManager    camera.CameraManager
 	configuredDevice string
 	appConfig        *config.AppConfig
+	detector         *detector.Detector
 }
 
 func New(
@@ -43,6 +49,7 @@ func New(
 	cameraManager camera.CameraManager,
 	deviceID string,
 	appConfig *config.AppConfig,
+	det *detector.Detector,
 ) *Server {
 	return &Server{
 		port:        port,
@@ -55,6 +62,7 @@ func New(
 		cameraManager:    cameraManager,
 		configuredDevice: deviceID, // store the camera device
 		appConfig:        appConfig,
+		detector:         det,
 	}
 }
 
@@ -131,6 +139,30 @@ func (s *Server) handleScreenshot(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to capture screenshot", http.StatusInternalServerError)
 		return
 	}
+
+	// Decode JPEG to Mat for detection
+	mat, err := gocv.IMDecode(frame, gocv.IMReadColor)
+	if err != nil {
+		s.addLog("ERROR", fmt.Sprintf("Decode error: %v", err))
+		http.Error(w, "Failed to process frame", http.StatusInternalServerError)
+		return
+	}
+	defer mat.Close()
+
+	var detections []detector.Detection
+	if s.detector != nil {
+		detections, _ = s.detector.Detect(mat)
+		for _, d := range detections {
+			gocv.Rectangle(&mat, d.Box, color.RGBA{0, 255, 0, 0}, 2)
+		}
+	}
+
+	buf, err := gocv.IMEncode(".jpg", mat)
+	if err == nil {
+		frame = buf.GetBytes()
+		buf.Close()
+	}
+
 	// ALWAYS return the image
 	w.Header().Set("Content-Type", "image/jpeg")
 	_, _ = w.Write(frame)
@@ -138,7 +170,6 @@ func (s *Server) handleScreenshot(w http.ResponseWriter, r *http.Request) {
 	// OPTIONAL: Also save it locally
 	storagePath := s.appConfig.StoragePath //
 	if storagePath != "" {
-		// e.g. /home/pi/birdcaptures or something
 		nowStr := time.Now().Format("20060102_150405")
 		filename := filepath.Join(storagePath, fmt.Sprintf("screenshot_%s.jpg", nowStr))
 
@@ -147,6 +178,12 @@ func (s *Server) handleScreenshot(w http.ResponseWriter, r *http.Request) {
 			s.addLog("ERROR", fmt.Sprintf("Failed to save screenshot to %s: %v", filename, err))
 		} else {
 			s.addLog("INFO", fmt.Sprintf("Screenshot saved to %s", filename))
+			meta := struct {
+				Timestamp  time.Time            `json:"timestamp"`
+				Detections []detector.Detection `json:"detections"`
+			}{time.Now(), detections}
+			metaBytes, _ := json.MarshalIndent(meta, "", "  ")
+			_ = os.WriteFile(strings.TrimSuffix(filename, ".jpg")+".json", metaBytes, 0644)
 		}
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/AlverezYari/featherframe/internal/config"
+	"github.com/AlverezYari/featherframe/internal/detector"
 	"github.com/AlverezYari/featherframe/internal/server"
 	"github.com/AlverezYari/featherframe/pkg/camera"
 	"github.com/charmbracelet/bubbles/viewport"
@@ -121,6 +122,8 @@ type Model struct {
 	logBuffer     []string      // Temporary buffer for new log lines
 	lastLogUpdate time.Time     // When logs were last flushed
 	logThrottle   time.Duration // Wait time between re-renders
+
+	detector *detector.Detector
 }
 
 func newCameraManager(logCallback func(level, message string)) camera.CameraManager {
@@ -194,8 +197,21 @@ func New(configPath string, cfg *config.AppConfig) *Model {
 	vp.SetContent("")
 	m.logViewport = vp
 
+	// Initialize detector using configuration
+	det, err := detector.New(
+		cfg.DetectionConfig.ModelPath,
+		cfg.DetectionConfig.LabelPath,
+		cfg.DetectionConfig.InputWidth,
+		cfg.DetectionConfig.InputHeight,
+		cfg.DetectionConfig.Confidence,
+	)
+	if err != nil {
+		m.flushLogImmediately("ERROR", fmt.Sprintf("Detector init failed: %v", err))
+	}
+	m.detector = det
+
 	// Start the server
-	m.server = server.New(cfg.ServerPort, m.logCallback, m.cameraManager, cfg.CameraConfig.DeviceID, cfg)
+	m.server = server.New(cfg.ServerPort, m.logCallback, m.cameraManager, cfg.CameraConfig.DeviceID, cfg, det)
 	if err := m.server.Start(); err != nil {
 		m.flushLogImmediately("ERROR", fmt.Sprintf("Error starting server: %v", err))
 	}


### PR DESCRIPTION
## Summary
- add initial detector package backed by gocv
- extend config with detection settings
- initialise detector in headless and TUI modes
- update server to use detector for screenshots

## Testing
- `go vet ./...` *(fails: no route to host)*