### PR TITLE
Improve build workflows for multi-arch

### DIFF
--- a/.github/workflows/ff-build-app.yaml
+++ b/.github/workflows/ff-build-app.yaml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          install: true
 
       - name: Login to registry
         uses: docker/login-action@v2
@@ -35,7 +37,9 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           file: ./Dockerfile
           push: true
           tags: ghcr.io/alverezyari/featherframe:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ff-build-container.yaml
+++ b/.github/workflows/ff-build-container.yaml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          install: true
 
       - name: Login to registry
         uses: docker/login-action@v2
@@ -36,7 +38,9 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/arm64,linux/amd64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           file: ./Dockerfile.build
           push: true
           tags: ghcr.io/alverezyari/featherframe:build
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ FROM ghcr.io/alverezyari/featherframe:build AS opencv-libs
 # -----------------------------------------------------------------------------
 FROM cgr.dev/chainguard/go:latest-dev AS builder-go
 
+ARG TARGETPLATFORM
+RUN echo "Building for $TARGETPLATFORM"
+
 USER root
 RUN apk update && apk add \
     pkgconf \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,6 +3,9 @@
 # ============================================================================
 FROM cgr.dev/chainguard/gcc-glibc:latest-dev AS builder-opencv
 
+ARG TARGETPLATFORM
+RUN echo "Building OpenCV for $TARGETPLATFORM"
+
 
 
 # The Chainguard c++ image has a Wolfi-based environment with clang, make, cmake, etc.


### PR DESCRIPTION
## Summary
- update `ff-build-app` for Buildx cache and arm/v7
- update `ff-build-container` for Buildx cache and arm/v7
- expose `TARGETPLATFORM` in Dockerfiles for easier debugging

## Testing
- `go vet ./...` *(fails: no route to host and incomplete packages)*