### PR TITLE
Improve build workflows for multi-arch

### DIFF
--- a/.github/workflows/ff-build-app.yaml
+++ b/.github/workflows/ff-build-app.yaml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          install: true
 
       - name: Login to registry
         uses: docker/login-action@v2
@@ -39,3 +41,5 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ghcr.io/alverezyari/featherframe:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ff-build-container.yaml
+++ b/.github/workflows/ff-build-container.yaml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          install: true
 
       - name: Login to registry
         uses: docker/login-action@v2
@@ -36,7 +38,9 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/arm64,linux/amd64
+          platforms: linux/amd64,linux/arm64
           file: ./Dockerfile.build
           push: true
           tags: ghcr.io/alverezyari/featherframe:build
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 # -----------------------------------------------------------------------------
 # Stage 1: Pull prebuilt OpenCV libs
 # -----------------------------------------------------------------------------
-FROM ghcr.io/alverezyari/featherframe:build AS opencv-libs
+FROM --platform=$BUILDPLATFORM ghcr.io/alverezyari/featherframe:build AS opencv-libs
 
 # -----------------------------------------------------------------------------
 # Stage 2: Build Go app
 # -----------------------------------------------------------------------------
-FROM cgr.dev/chainguard/go:latest-dev AS builder-go
+FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/go:latest-dev AS builder-go
+
+ARG TARGETPLATFORM
+RUN echo "Building for $TARGETPLATFORM"
 
 USER root
 RUN apk update && apk add \
@@ -39,7 +42,7 @@ RUN go build -o /tmp/feather-finder cmd/featherframe/main.go
 # -----------------------------------------------------------------------------
 # Stage 3: Minimal runtime
 # -----------------------------------------------------------------------------
-FROM cgr.dev/chainguard/glibc-dynamic:latest
+FROM --platform=$TARGETPLATFORM cgr.dev/chainguard/glibc-dynamic:latest
 
 # Copy OpenCV from prebuilt image
 COPY --from=opencv-libs /usr/local /usr/local

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,7 +1,10 @@
 # ============================================================================
 # Stage 1: Build OpenCV
 # ============================================================================
-FROM cgr.dev/chainguard/gcc-glibc:latest-dev AS builder-opencv
+FROM --platform=$BUILDPLATFORM cgr.dev/chainguard/gcc-glibc:latest-dev AS builder-opencv
+
+ARG TARGETPLATFORM
+RUN echo "Building OpenCV for $TARGETPLATFORM"
 
 
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,13 @@ To enable headless mode set `"headless": true` in the config file.
 
 ## Container Usage
 
-A Dockerfile is not provided, but the application should work with the official
-`gocv` images for ARM64. Install OpenCV and gocv in the container, copy the
-source, then build:
+A Dockerfile is provided so the application can be built for multiple
+architectures. To create a container for amd64 and arm64 (suitable for
+Raspberry Pi 4 and similar devices) run:
 
-```
-FROM gocv/gocv:latest
-WORKDIR /app
-COPY . .
-RUN go build -o featherframe cmd/featherframe/main.go
-CMD ["./featherframe"]
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t ghcr.io/alverezyari/featherframe:latest .
 ```
 
 Bind mount `/dev/video0` and expose the configured port.


### PR DESCRIPTION
## Summary
- update `ff-build-app` to skip arm/v7
- update `ff-build-container` to skip arm/v7
- set explicit build platforms in Dockerfiles
- refresh README with Docker build instructions

## Testing
- `go vet ./...` *(fails: no route to host and incomplete packages)*
