### PR TITLE
Fix buildx failure on develop actions

### DIFF
--- a/.github/workflows/ff-build-app.yaml
+++ b/.github/workflows/ff-build-app.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           file: ./Dockerfile
           push: true
           tags: ghcr.io/alverezyari/featherframe:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN go build -o /tmp/feather-finder cmd/featherframe/main.go
 # -----------------------------------------------------------------------------
 # Stage 3: Minimal runtime
 # -----------------------------------------------------------------------------
-FROM --platform=$TARGETPLATFORM cgr.dev/chainguard/glibc-dynamic:latest
+FROM cgr.dev/chainguard/glibc-dynamic:latest
 
 # Copy OpenCV from prebuilt image
 COPY --from=opencv-libs /usr/local /usr/local


### PR DESCRIPTION
## Summary
- remove arm v7 from the app workflow platforms
- remove redundant TARGETPLATFORM in runtime stage

## Testing
- `go vet ./...` *(fails: no route to host)*
- `go test ./...` *(fails: no route to host)*