### PR TITLE
Add SMS alerts for bird detection

### DIFF
--- a/internal/alerts/alerts.go
+++ b/internal/alerts/alerts.go
@@ -1,0 +1,48 @@
+package alerts
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/AlverezYari/featherframe/internal/config"
+)
+
+// SendBirdAlert sends an SMS about a bird detection using Twilio's REST API.
+// The AlertConfig must contain all required fields.
+func SendBirdAlert(bird string, cfg *config.AlertConfig) error {
+	if cfg == nil {
+		return fmt.Errorf("alert config is nil")
+	}
+	if cfg.ToNumber == "" || cfg.FromNumber == "" || cfg.AccountSID == "" || cfg.AuthToken == "" {
+		return fmt.Errorf("alert configuration incomplete")
+	}
+
+	msgData := url.Values{}
+	msgData.Set("To", cfg.ToNumber)
+	msgData.Set("From", cfg.FromNumber)
+	msgData.Set("Body", fmt.Sprintf("Bird detected: %s", bird))
+
+	urlStr := fmt.Sprintf("https://api.twilio.com/2010-04-01/Accounts/%s/Messages.json", cfg.AccountSID)
+	req, err := http.NewRequest("POST", urlStr, strings.NewReader(msgData.Encode()))
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth(cfg.AccountSID, cfg.AuthToken)
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("twilio error: %s", string(b))
+	}
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,14 @@ type DetectionConfig struct {
 	InputHeight int     `json:"input_height"`
 }
 
+type AlertConfig struct {
+	BirdLabel  string `json:"bird_label"`
+	ToNumber   string `json:"to_number"`
+	FromNumber string `json:"from_number"`
+	AccountSID string `json:"account_sid"`
+	AuthToken  string `json:"auth_token"`
+}
+
 type AppConfig struct {
 	ServerPort      string          `json:"server_port"`
 	ServerIP        string          `json:"server_ip"`
@@ -35,6 +43,7 @@ type AppConfig struct {
 	StoragePath     string          `json:"storage_path"`
 	Headless        bool            `json:"headless"`
 	DetectionConfig DetectionConfig `json:"detection"`
+	AlertConfig     AlertConfig     `json:"alert"`
 }
 
 // Default config
@@ -57,6 +66,13 @@ func defaultConfig() *AppConfig {
 			Confidence:  0.5,
 			InputWidth:  640,
 			InputHeight: 640,
+		},
+		AlertConfig: AlertConfig{
+			BirdLabel:  "bird",
+			ToNumber:   "",
+			FromNumber: "",
+			AccountSID: "",
+			AuthToken:  "",
 		},
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/AlverezYari/featherframe/internal/alerts"
 	"github.com/AlverezYari/featherframe/internal/config"
 	"github.com/AlverezYari/featherframe/internal/detector"
 	"github.com/AlverezYari/featherframe/internal/metrics"
@@ -154,6 +155,12 @@ func (s *Server) handleScreenshot(w http.ResponseWriter, r *http.Request) {
 		detections, _ = s.detector.Detect(mat)
 		for _, d := range detections {
 			gocv.Rectangle(&mat, d.Box, color.RGBA{0, 255, 0, 0}, 2)
+			if strings.EqualFold(d.Label, s.appConfig.AlertConfig.BirdLabel) {
+				if err := alerts.SendBirdAlert(d.Label, &s.appConfig.AlertConfig); err != nil {
+					s.addLog("ERROR", fmt.Sprintf("alert error: %v", err))
+				}
+				metrics.IncrementBirdsSeen()
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- allow configuring SMS alerts via `AlertConfig`
- send alerts when matching bird label is detected
- add Twilio REST call helper

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.25.0.3:8080: connect: no route to host)*