### PR TITLE
Add location config and local bird data endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,17 @@ Additional generic metrics are exposed:
 
 - `http_requests_total` – total HTTP requests served
 - `uptime_seconds` – seconds since the server started
+
+## Local Bird Data
+
+Set your location in `config.json` using the `location` section:
+
+```json
+"location": {
+  "latitude": 0,
+  "longitude": 0
+}
+```
+
+The endpoint `/api/local_birds` fetches recent bird recordings near your
+configured GPS coordinates using the public xeno-canto API.

--- a/internal/birddata/birddata.go
+++ b/internal/birddata/birddata.go
@@ -1,0 +1,42 @@
+package birddata
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Recording represents a single result from the xeno-canto API.
+type Recording struct {
+	ID      string `json:"id"`
+	Genus   string `json:"gen"`
+	Species string `json:"sp"`
+	English string `json:"en"`
+	File    string `json:"file"`
+}
+
+// Response mirrors the response from the xeno-canto API.
+type Response struct {
+	NumRecordings string      `json:"numRecordings"`
+	Recordings    []Recording `json:"recordings"`
+}
+
+// Fetch retrieves recent bird recordings near the provided lat/lon using the
+// xeno-canto API.
+func Fetch(lat, lon float64) (Response, error) {
+	url := fmt.Sprintf("https://xeno-canto.org/api/2/recordings?query=lat:%f+lon:%f", lat, lon)
+	resp, err := http.Get(url)
+	if err != nil {
+		return Response{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return Response{}, fmt.Errorf("API status: %s", resp.Status)
+	}
+
+	var r Response
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return Response{}, err
+	}
+	return r, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,12 @@ type DetectionConfig struct {
 	InputHeight int     `json:"input_height"`
 }
 
+// Location stores the latitude and longitude used for pulling regional bird data.
+type Location struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}
+
 type AppConfig struct {
 	ServerPort      string          `json:"server_port"`
 	ServerIP        string          `json:"server_ip"`
@@ -35,6 +41,7 @@ type AppConfig struct {
 	StoragePath     string          `json:"storage_path"`
 	Headless        bool            `json:"headless"`
 	DetectionConfig DetectionConfig `json:"detection"`
+	Location        Location        `json:"location"`
 }
 
 // Default config
@@ -57,6 +64,10 @@ func defaultConfig() *AppConfig {
 			Confidence:  0.5,
 			InputWidth:  640,
 			InputHeight: 640,
+		},
+		Location: Location{
+			Latitude:  0,
+			Longitude: 0,
 		},
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/AlverezYari/featherframe/internal/birddata"
 	"github.com/AlverezYari/featherframe/internal/config"
 	"github.com/AlverezYari/featherframe/internal/detector"
 	"github.com/AlverezYari/featherframe/internal/metrics"
@@ -108,6 +109,7 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/metrics", metrics.MetricsHandler)
 	mux.HandleFunc("/api/birds_sceen", metrics.BirdsSeenHandler)
 	mux.HandleFunc("/api/birds_captured", metrics.BirdsCapturedHandler)
+	mux.HandleFunc("/api/local_birds", s.handleLocalBirds)
 
 	// Build and start the HTTP server
 	s.server = &http.Server{
@@ -186,6 +188,20 @@ func (s *Server) handleScreenshot(w http.ResponseWriter, r *http.Request) {
 			_ = os.WriteFile(strings.TrimSuffix(filename, ".jpg")+".json", metaBytes, 0644)
 		}
 	}
+}
+
+// handleLocalBirds returns recent bird recordings near the configured location.
+func (s *Server) handleLocalBirds(w http.ResponseWriter, r *http.Request) {
+	lat := s.appConfig.Location.Latitude
+	lon := s.appConfig.Location.Longitude
+	data, err := birddata.Fetch(lat, lon)
+	if err != nil {
+		s.addLog("ERROR", fmt.Sprintf("Bird data fetch error: %v", err))
+		http.Error(w, "failed to fetch bird data", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(data)
 }
 
 func (s *Server) Stop() error {


### PR DESCRIPTION
## Summary
- add `Location` to config with latitude and longitude
- implement `birddata` package for fetching local bird info via xeno‑canto
- expose new `/api/local_birds` route in the server
- document location config and endpoint in README

## Testing
- `go test ./...` *(fails: no route to host)*